### PR TITLE
Adjust logs

### DIFF
--- a/consul.go
+++ b/consul.go
@@ -15,19 +15,27 @@ func newConsulClient(consulAPI, consulToken string) (*consulapi.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	glog.V(2).Infof("Testing communication with consul server")
 	_, err = consulClient.Status().Leader()
 	if err != nil {
 		return nil, fmt.Errorf("ERROR communicating with consul server: %v", err)
 	}
-	glog.V(2).Infof("Communication with consul server successful")
-
 	return consulClient, nil
 }
 
-func (k2c *kube2consul) registerEndpoint(e Endpoint) {
+func (k2c *kube2consul) registerEndpoint(e Endpoint) error {
 	if e.RefName == "" {
-		return
+		return nil
+	}
+
+	consulServices, _, err := k2c.consulCatalog.Service(e.Name, consulTag, nil)
+	if err != nil {
+		return fmt.Errorf("Failed to get services: %v", err)
+	}
+
+	for _, service := range consulServices {
+		if endpointExists(service.Node, service.Address, service.ServicePort, []Endpoint{e}) {
+			return nil
+		}
 	}
 
 	service := &consulapi.AgentService{
@@ -42,12 +50,13 @@ func (k2c *kube2consul) registerEndpoint(e Endpoint) {
 		Service: service,
 	}
 
-	_, err := k2c.consulCatalog.Register(reg, nil)
+	_, err = k2c.consulCatalog.Register(reg, nil)
 	if err != nil {
-		glog.Errorf("Error registrating service %v (%v, %v): %v", e.Name, e.RefName, e.Address, err)
-	} else {
-		glog.V(1).Infof("Update service %v (%v, %v)", e.Name, e.RefName, e.Address)
+		return fmt.Errorf("Error registrating service %v (%v, %v): %v", e.Name, e.RefName, e.Address, err)
 	}
+	glog.Infof("Update service %v (%v, %v)", e.Name, e.RefName, e.Address)
+
+	return nil
 }
 
 func endpointExists(refName, address string, port int, endpoints []Endpoint) bool {
@@ -59,12 +68,11 @@ func endpointExists(refName, address string, port int, endpoints []Endpoint) boo
 	return false
 }
 
-func (k2c *kube2consul) removeDeletedEndpoints(serviceName string, endpoints []Endpoint) {
+func (k2c *kube2consul) removeDeletedEndpoints(serviceName string, endpoints []Endpoint) error {
 	updatedNodes := make(map[string]struct{})
 	services, _, err := k2c.consulCatalog.Service(serviceName, consulTag, nil)
 	if err != nil {
-		glog.Errorf("[Consul] Failed to get services: %v", err)
-		return
+		return fmt.Errorf("Failed to get services: %v", err)
 	}
 
 	for _, service := range services {
@@ -76,28 +84,28 @@ func (k2c *kube2consul) removeDeletedEndpoints(serviceName string, endpoints []E
 			}
 			_, err := k2c.consulCatalog.Deregister(dereg, nil)
 			if err != nil {
-				glog.Errorf("Error deregistrating service {node: %s, service: %s, address: %s}: %v", service.Node, service.ServiceName, service.Address, err)
-			} else {
-				glog.Infof("Deregister service {node: %s, service: %s, address: %s}", service.Node, service.ServiceName, service.Address)
-				updatedNodes[service.Node] = struct{}{}
+				return fmt.Errorf("Error deregistrating service {node: %s, service: %s, address: %s}: %v", service.Node, service.ServiceName, service.Address, err)
 			}
+			glog.Infof("Deregister service {node: %s, service: %s, address: %s}", service.Node, service.ServiceName, service.Address)
+			updatedNodes[service.Node] = struct{}{}
 		}
 	}
 
 	// Remove all empty nodes
 	for nodeName := range updatedNodes {
-		if node, _, err := k2c.consulCatalog.Node(nodeName, nil); err != nil {
-			glog.Errorf("Cannot get node %s: %v", nodeName, err)
+		node, _, err := k2c.consulCatalog.Node(nodeName, nil)
+		if err != nil {
+			return fmt.Errorf("Cannot get node %s: %v", nodeName, err)
 		} else if node != nil && len(node.Services) == 0 {
 			dereg := &consulapi.CatalogDeregistration{
 				Node: nodeName,
 			}
 			_, err = k2c.consulCatalog.Deregister(dereg, nil)
 			if err != nil {
-				glog.Errorf("Error deregistrating node %s: %v", nodeName, err)
-			} else {
-				glog.Infof("Deregister empty node %s", nodeName)
+				return fmt.Errorf("Error deregistrating node %s: %v", nodeName, err)
 			}
+			glog.Infof("Deregister empty node %s", nodeName)
 		}
 	}
+	return nil
 }

--- a/endpoint.go
+++ b/endpoint.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
@@ -37,11 +38,15 @@ func generateEntries(endpoint *v1.Endpoints) []Endpoint {
 	return eps
 }
 
-func (k2c *kube2consul) updateEndpoints(ep *v1.Endpoints) {
+func (k2c *kube2consul) updateEndpoints(ep *v1.Endpoints) error {
 	endpoints := generateEntries(ep)
 	for _, e := range endpoints {
-		k2c.registerEndpoint(e)
+		if err := k2c.registerEndpoint(e); err != nil {
+			return fmt.Errorf("Error updating endpoints %v: %v", ep.Name, err)
+		}
 	}
-
-	k2c.removeDeletedEndpoints(ep.Name, endpoints)
+	if err := k2c.removeDeletedEndpoints(ep.Name, endpoints); err != nil {
+		return fmt.Errorf("Error removing possible deleted endpoints: %v", err)
+	}
+	return nil
 }

--- a/kubernetes.go
+++ b/kubernetes.go
@@ -57,13 +57,10 @@ func newKubeClient(apiserver string, kubeconfig string) (kubeClient kubernetes.I
 	// Informers don't seem to do a good job logging error messages when it
 	// can't reach the server, making debugging hard. This makes it easier to
 	// figure out if apiserver is configured incorrectly.
-	glog.V(2).Infof("Testing communication with k8s apiserver")
 	_, err = kubeClient.Discovery().ServerVersion()
 	if err != nil {
 		return nil, fmt.Errorf("ERROR communicating with k8s apiserver: %v", err)
 	}
-	glog.V(2).Infof("Communication with k8s apiserver successful")
-
 	return kubeClient, nil
 }
 
@@ -75,7 +72,9 @@ func createEndpointsListWatcher(kubeClient kubernetes.Interface) *kcache.ListWat
 
 func (k2c *kube2consul) handleEndpointUpdate(obj interface{}) {
 	if e, ok := obj.(*v1.Endpoints); ok {
-		k2c.updateEndpoints(e)
+		if err := k2c.updateEndpoints(e); err != nil {
+			glog.Errorf("Error handling update event: %v", err)
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -92,7 +92,10 @@ func (k2c *kube2consul) RemoveDNSGarbage() {
 		}
 
 		if _, ok := epSet[name]; !ok {
-			k2c.removeDeletedEndpoints(name, []Endpoint{})
+			err = k2c.removeDeletedEndpoints(name, []Endpoint{})
+			if err != nil {
+				glog.Errorf("Error removing DNS garbage: %v", err)
+			}
 		}
 	}
 }
@@ -116,7 +119,10 @@ func kubernetesCheck() error {
 func main() {
 	// parse flags
 	flag.Parse()
-	flagutil.SetFlagsFromEnv(flag.CommandLine, "K2C")
+	err := flagutil.SetFlagsFromEnv(flag.CommandLine, "K2C")
+	if err != nil {
+		glog.Fatalf("Cannot set flags from env: %v", err)
+	}
 
 	if opts.version {
 		fmt.Println(kube2consulVersion)


### PR DESCRIPTION
k2c was too noisy, this reduces various unecessary logs, especially when
resyncing services from k8s. In order to do that endpoints are not updated if
they already exist.